### PR TITLE
adapt for binary outputs

### DIFF
--- a/fungi-coord/main.go
+++ b/fungi-coord/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -215,7 +214,7 @@ func (c *Coordinator) writeResult(job int, res *fungi.JobResult) error {
 	}
 	defer fi.Close()
 
-	if err := json.NewEncoder(fi).Encode(res); err != nil {
+	if _, err := fi.Write(res.Output); err != nil {
 		return xerrors.Errorf("failed to write result to file: %w", err)
 	}
 	return nil

--- a/fungi-worker/main.go
+++ b/fungi-worker/main.go
@@ -159,7 +159,7 @@ func (w *Worker) Execute(ja *fungi.JobAllocation) {
 		res := &fungi.JobResult{
 			JobID:   ja.ID,
 			Success: false,
-			Output:  string(out),
+			Output:  out,
 		}
 		w.Results <- res
 		return
@@ -168,7 +168,7 @@ func (w *Worker) Execute(ja *fungi.JobAllocation) {
 	w.Results <- &fungi.JobResult{
 		JobID:   ja.ID,
 		Success: true,
-		Output:  string(out),
+		Output:  out,
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -19,7 +19,7 @@ type JobConfig struct {
 type JobResult struct {
 	JobID   int
 	Success bool
-	Output  string
+	Output  []byte
 }
 
 func LoadJobConfig(fn string) (*JobConfig, error) {


### PR DESCRIPTION
My binary output from the simulator is getting corrupted while passing through “fungi”. I poked at it with a hex differ, and there’s a lot of data being replaced by EFBFBD sequences. Googling “go EFBFBD” yields [go-ipfs/issues#3522](https://github.com/ipfs/go-ipfs/issues/3522). Just the folks I wanted to see! @whyrusleeping @dignifiedquire Here's the fix in fungi. CC @zixuanzh